### PR TITLE
Ref #97: Replace built-in shadowed str with input_string

### DIFF
--- a/snippets/byte_size.md
+++ b/snippets/byte_size.md
@@ -5,11 +5,11 @@ tags: string, beginner
 
 Returns the length of a string in bytes.
 
-Use `input_string.encode('utf-8')` to encode the given string and return its length.
+Use `s.encode('utf-8')` to encode the given string and return its length.
 
 ```py
-def byte_size(input_string):
-  return len(input_string.encode('utf-8'))
+def byte_size(s):
+  return len(s.encode('utf-8'))
 ```
 
 ```py

--- a/snippets/byte_size.md
+++ b/snippets/byte_size.md
@@ -5,11 +5,11 @@ tags: string, beginner
 
 Returns the length of a string in bytes.
 
-Use `string.encode('utf-8')` to encode the given string and return its length.
+Use `input_string.encode('utf-8')` to encode the given string and return its length.
 
 ```py
-def byte_size(string):
-  return len(string.encode('utf-8'))
+def byte_size(input_string):
+  return len(input_string.encode('utf-8'))
 ```
 
 ```py

--- a/snippets/camel.md
+++ b/snippets/camel.md
@@ -10,9 +10,9 @@ Break the string into words and combine them capitalizing the first letter of ea
 ```py
 import re
 
-def camel(s):
-  s = re.sub(r"(\s|_|-)+", " ", s).title().replace(" ", "")
-  return s[0].lower() + s[1:]
+def camel(input_string):
+  input_string = re.sub(r"(\s|_|-)+", " ", input_string).title().replace(" ", "")
+  return input_string[0].lower() + s[1:]
 ```
 
 ```py

--- a/snippets/camel.md
+++ b/snippets/camel.md
@@ -10,9 +10,9 @@ Break the string into words and combine them capitalizing the first letter of ea
 ```py
 import re
 
-def camel(input_string):
-  input_string = re.sub(r"(\s|_|-)+", " ", input_string).title().replace(" ", "")
-  return input_string[0].lower() + s[1:]
+def camel(s):
+  s = re.sub(r"(\s|_|-)+", " ", s).title().replace(" ", "")
+  return s[0].lower() + s[1:]
 ```
 
 ```py

--- a/snippets/capitalize.md
+++ b/snippets/capitalize.md
@@ -9,8 +9,8 @@ Capitalize the first letter of the string and then add it with rest of the strin
 Omit the `lower_rest` parameter to keep the rest of the string intact, or set it to `True` to convert to lowercase.
 
 ```py
-def capitalize(string, lower_rest=False):
-  return string[:1].upper() + (string[1:].lower() if lower_rest else string[1:])
+def capitalize(input_string, lower_rest=False):
+  return input_string[:1].upper() + (input_string[1:].lower() if lower_rest else input_string[1:])
 ```
 
 ```py

--- a/snippets/capitalize.md
+++ b/snippets/capitalize.md
@@ -9,8 +9,8 @@ Capitalize the first letter of the string and then add it with rest of the strin
 Omit the `lower_rest` parameter to keep the rest of the string intact, or set it to `True` to convert to lowercase.
 
 ```py
-def capitalize(input_string, lower_rest=False):
-  return input_string[:1].upper() + (input_string[1:].lower() if lower_rest else input_string[1:])
+def capitalize(s, lower_rest=False):
+  return s[:1].upper() + (s[1:].lower() if lower_rest else s[1:])
 ```
 
 ```py

--- a/snippets/capitalize_every_word.md
+++ b/snippets/capitalize_every_word.md
@@ -5,11 +5,11 @@ tags: string,beginner
 
 Capitalizes the first letter of every word in a string.
 
-Use `string.title()` to capitalize first letter of every word in the string.
+Use `input_string.title()` to capitalize first letter of every word in the string.
 
 ```py
-def capitalize_every_word(string):
-  return string.title()
+def capitalize_every_word(input_string):
+  return input_string.title()
 ```
 
 ```py

--- a/snippets/capitalize_every_word.md
+++ b/snippets/capitalize_every_word.md
@@ -5,11 +5,11 @@ tags: string,beginner
 
 Capitalizes the first letter of every word in a string.
 
-Use `input_string.title()` to capitalize first letter of every word in the string.
+Use `s.title()` to capitalize first letter of every word in the string.
 
 ```py
-def capitalize_every_word(input_string):
-  return input_string.title()
+def capitalize_every_word(s):
+  return s.title()
 ```
 
 ```py

--- a/snippets/decapitalize.md
+++ b/snippets/decapitalize.md
@@ -9,8 +9,8 @@ Decapitalize the first letter of the string and then add it with rest of the str
 Omit the `upper_rest` parameter to keep the rest of the string intact, or set it to `True` to convert to uppercase.
 
 ```py
-def decapitalize(str, upper_rest=False):
-  return str[:1].lower() + (str[1:].upper() if upper_rest else str[1:])
+def decapitalize(input_string, upper_rest=False):
+  return input_string[:1].lower() + (input_string[1:].upper() if upper_rest else input_string[1:])
 ```
 
 ```py

--- a/snippets/decapitalize.md
+++ b/snippets/decapitalize.md
@@ -9,8 +9,8 @@ Decapitalize the first letter of the string and then add it with rest of the str
 Omit the `upper_rest` parameter to keep the rest of the string intact, or set it to `True` to convert to uppercase.
 
 ```py
-def decapitalize(input_string, upper_rest=False):
-  return input_string[:1].lower() + (input_string[1:].upper() if upper_rest else input_string[1:])
+def decapitalize(s, upper_rest=False):
+  return s[:1].lower() + (s[1:].upper() if upper_rest else s[1:])
 ```
 
 ```py

--- a/snippets/is_anagram.md
+++ b/snippets/is_anagram.md
@@ -5,13 +5,13 @@ tags: string,intermediate
 
 Checks if a string is an anagram of another string (case-insensitive, ignores spaces, punctuation and special characters).
 
-Use `str.replace()` to remove spaces from both strings.
+Use `input_string.replace()` to remove spaces from both strings.
 Compare the lengths of the two strings, return `False` if they are not equal.
 Use `sorted()` on both strings and compare the results.
 
 ```py
-def is_anagram(str1, str2):
-  _str1, _str2 = str1.replace(" ", ""), str2.replace(" ", "")
+def is_anagram(input_string_1, input_string_2):
+  _str1, _str2 = input_string_1.replace(" ", ""), input_string_2.replace(" ", "")
 
   if len(_str1) != len(_str2):
     return False

--- a/snippets/is_anagram.md
+++ b/snippets/is_anagram.md
@@ -5,13 +5,13 @@ tags: string,intermediate
 
 Checks if a string is an anagram of another string (case-insensitive, ignores spaces, punctuation and special characters).
 
-Use `input_string.replace()` to remove spaces from both strings.
+Use `s.replace()` to remove spaces from both strings.
 Compare the lengths of the two strings, return `False` if they are not equal.
 Use `sorted()` on both strings and compare the results.
 
 ```py
-def is_anagram(input_string_1, input_string_2):
-  _str1, _str2 = input_string_1.replace(" ", ""), input_string_2.replace(" ", "")
+def is_anagram(s1, s2):
+  _str1, _str2 = s1.replace(" ", ""), s2.replace(" ", "")
 
   if len(_str1) != len(_str2):
     return False

--- a/snippets/kebab.md
+++ b/snippets/kebab.md
@@ -10,10 +10,10 @@ Break the string into words and combine them adding `-` as a separator, using a 
 ```py
 import re
 
-def kebab(str):
+def kebab(input_string):
   return re.sub(r"(\s|_|-)+","-",
     re.sub(r"[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+",
-    lambda mo: mo.group(0).lower(),str)
+    lambda mo: mo.group(0).lower(), input_string)
   )
 ```
 

--- a/snippets/kebab.md
+++ b/snippets/kebab.md
@@ -10,10 +10,10 @@ Break the string into words and combine them adding `-` as a separator, using a 
 ```py
 import re
 
-def kebab(input_string):
+def kebab(s):
   return re.sub(r"(\s|_|-)+","-",
     re.sub(r"[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+",
-    lambda mo: mo.group(0).lower(), input_string)
+    lambda mo: mo.group(0).lower(), s)
   )
 ```
 

--- a/snippets/n_times_string.md
+++ b/snippets/n_times_string.md
@@ -8,8 +8,8 @@ Prints out the same string a defined number of times.
 Repeat the string `n` times, using the `*` operator.
 
 ```py
-def n_times_string(input_string, n):
-  return (input_string * n)
+def n_times_string(s, n):
+  return (s * n)
 ```
 
 ```py

--- a/snippets/n_times_string.md
+++ b/snippets/n_times_string.md
@@ -8,8 +8,8 @@ Prints out the same string a defined number of times.
 Repeat the string `n` times, using the `*` operator.
 
 ```py
-def n_times_string(str,n):
-  return (str * n)
+def n_times_string(input_string, n):
+  return (input_string * n)
 ```
 
 ```py

--- a/snippets/palindrome.md
+++ b/snippets/palindrome.md
@@ -5,14 +5,14 @@ tags: string,intermediate
 
 Returns `True` if the given string is a palindrome, `False` otherwise.
 
-Use `str.lower()` and `re.sub()` to convert to lowercase and  remove non-alphanumeric characters from the given string. 
+Use `input_string.lower()` and `re.sub()` to convert to lowercase and  remove non-alphanumeric characters from the given string. 
 Then, compare the new string with its reverse.
 
 ```py
 from re import sub
 
-def palindrome(string):
-  s = sub('[\W_]', '', string.lower())
+def palindrome(input_string):
+  s = sub('[\W_]', '', input_string.lower())
   return s == s[::-1]
 ```
 

--- a/snippets/palindrome.md
+++ b/snippets/palindrome.md
@@ -5,14 +5,14 @@ tags: string,intermediate
 
 Returns `True` if the given string is a palindrome, `False` otherwise.
 
-Use `input_string.lower()` and `re.sub()` to convert to lowercase and  remove non-alphanumeric characters from the given string. 
+Use `s.lower()` and `re.sub()` to convert to lowercase and  remove non-alphanumeric characters from the given string. 
 Then, compare the new string with its reverse.
 
 ```py
 from re import sub
 
-def palindrome(input_string):
-  s = sub('[\W_]', '', input_string.lower())
+def palindrome(s):
+  s = sub('[\W_]', '', s.lower())
   return s == s[::-1]
 ```
 

--- a/snippets/snake.md
+++ b/snippets/snake.md
@@ -10,10 +10,10 @@ Break the string into words and combine them adding `_` as a separator, using a 
 ```py
 import re
 
-def snake(str):
+def snake(input_string):
   return '_'.join(re.sub('([A-Z][a-z]+)', r' \1',
     re.sub('([A-Z]+)', r' \1',
-    str.replace('-', ' '))).split()).lower()
+    input_string.replace('-', ' '))).split()).lower()
 ```
 
 ```py

--- a/snippets/snake.md
+++ b/snippets/snake.md
@@ -10,10 +10,10 @@ Break the string into words and combine them adding `_` as a separator, using a 
 ```py
 import re
 
-def snake(input_string):
+def snake(s):
   return '_'.join(re.sub('([A-Z][a-z]+)', r' \1',
     re.sub('([A-Z]+)', r' \1',
-    input_string.replace('-', ' '))).split()).lower()
+    s.replace('-', ' '))).split()).lower()
 ```
 
 ```py

--- a/snippets/split_lines.md
+++ b/snippets/split_lines.md
@@ -5,11 +5,11 @@ tags: string,beginner
 
 Splits a multiline string into a list of lines.
 
-Use `input_string.split()` and `'\n'` to match line breaks and create a list.
+Use `s.split()` and `'\n'` to match line breaks and create a list.
 
 ```py
-def split_lines(input_string):
-  return input_string.split('\n')
+def split_lines(s):
+  return s.split('\n')
 ```
 
 ```py

--- a/snippets/split_lines.md
+++ b/snippets/split_lines.md
@@ -5,11 +5,11 @@ tags: string,beginner
 
 Splits a multiline string into a list of lines.
 
-Use `str.split()` and `'\n'` to match line breaks and create a list.
+Use `input_string.split()` and `'\n'` to match line breaks and create a list.
 
 ```py
-def split_lines(str):
-  return str.split('\n')
+def split_lines(input_string):
+  return input_string.split('\n')
 ```
 
 ```py


### PR DESCRIPTION
## Description
**Addresses** #97

This isn't a full fix for issue 97, but a first stab at it. The issue has more details, but the quick synopsis is that several of the string examples were shadowing the Python built-in function `str`. That being said, it is also related to Pull Request #127 where just a couple days ago one of the snippets was re-written this way.

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. <!-- Check this only if you have updated tag_database and ran lint.py and readme.py in the scripts folder -->
- [ ] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
