### PR TITLE
Fix typo in fibonacci snippet

### DIFF
--- a/snippet_data/snippetList.json
+++ b/snippet_data/snippetList.json
@@ -391,7 +391,7 @@
       "type": "snippetListing",
       "title": "fibonacci",
       "attributes": {
-        "text": "Generates an array, containing the Fibonacci sequence, up until the nth term.\n\nStarting with `0` and `1`, use `list.apoend() to add the sum of the last two numbers of the list to the end of the list, until the length of the list reaches `n`.  \nIf `n` is less or equal to `0`, return a list containing `0`.\n\n",
+        "text": "Generates an array, containing the Fibonacci sequence, up until the nth term.\n\nStarting with `0` and `1`, use `list.append() to add the sum of the last two numbers of the list to the end of the list, until the length of the list reaches `n`.  \nIf `n` is less or equal to `0`, return a list containing `0`.\n\n",
         "tags": [
           "math",
           "list",

--- a/snippet_data/snippets.json
+++ b/snippet_data/snippets.json
@@ -517,7 +517,7 @@
       "type": "snippet",
       "attributes": {
         "fileName": "fibonacci.md",
-        "text": "Generates an array, containing the Fibonacci sequence, up until the nth term.\n\nStarting with `0` and `1`, use `list.apoend() to add the sum of the last two numbers of the list to the end of the list, until the length of the list reaches `n`.  \nIf `n` is less or equal to `0`, return a list containing `0`.\n\n",
+        "text": "Generates an array, containing the Fibonacci sequence, up until the nth term.\n\nStarting with `0` and `1`, use `list.append() to add the sum of the last two numbers of the list to the end of the list, until the length of the list reaches `n`.  \nIf `n` is less or equal to `0`, return a list containing `0`.\n\n",
         "codeBlocks": {
           "code": "def fibonacci(n):\r\n  if n <= 0:\r\n    return [0]\r\n\r\n  sequence = [0, 1]\r\n  while len(sequence) <= n:\r\n    next_value = sequence[len(sequence) - 1] + sequence[len(sequence) - 2]\r\n    sequence.append(next_value)\r\n\r\n  return sequence",
           "example": "fibonacci(7) # [0, 1, 1, 2, 3, 5, 8, 13]"

--- a/snippets/fibonacci.md
+++ b/snippets/fibonacci.md
@@ -5,7 +5,7 @@ tags: math,list,intermediate
 
 Generates an array, containing the Fibonacci sequence, up until the nth term.
 
-Starting with `0` and `1`, use `list.apoend() to add the sum of the last two numbers of the list to the end of the list, until the length of the list reaches `n`.  
+Starting with `0` and `1`, use `list.append() to add the sum of the last two numbers of the list to the end of the list, until the length of the list reaches `n`.  
 If `n` is less or equal to `0`, return a list containing `0`.
 
 ```py


### PR DESCRIPTION
Fix typo in fibonacci snippet

## Description
Change `apoend` to `append ` in documentation/description.

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. <!-- Check this only if you have updated tag_database and ran lint.py and readme.py in the scripts folder -->
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
