### PR TITLE
make consistent with keys_only

### DIFF
--- a/snippets/values_only.md
+++ b/snippets/values_only.md
@@ -9,8 +9,8 @@ Use `dict.values()` to return the values in the given dictionary.
 Return a `list()` of the previous result.
 
 ```py
-def values_only(dict):
-  return list(dict.values())
+def values_only(flat_dict):
+  return list(flat_dict.values())
 ```
 
 ```py


### PR DESCRIPTION
https://github.com/30-seconds/30-seconds-of-python#keys_only names parameter `flat_dict`, which avoids shadowing `dict`, seems like the right approach for here as well

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. <!-- Check this only if you have updated tag_database and ran lint.py and readme.py in the scripts folder -->
- [ ] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
