### PR TITLE
Fix typo in head

### DIFF
--- a/snippets/head.md
+++ b/snippets/head.md
@@ -5,7 +5,7 @@ tags: list,beginner
 
 Returns the head of a list.
 
-use `lst[0]` to return the first element of the passed list.
+Use `lst[0]` to return the first element of the passed list.
 
 ```py
 def head(lst):


### PR DESCRIPTION
Minor formatting issue (capitalization) in `head` snippet.