### PR TITLE
bug fix in gcd.md

### DIFF
--- a/snippets/gcd.md
+++ b/snippets/gcd.md
@@ -9,10 +9,10 @@ Use `functools.reduce()` and `math.gcd()` over the given list.
 
 ```py
 from functools import reduce
-from math import gcd as gcd_from_math
+from math import gcd as _gcd
 
 def gcd(numbers):
-  return reduce(gcd_from_math, numbers)
+  return reduce(_gcd, numbers)
 ```
 
 ```py

--- a/snippets/gcd.md
+++ b/snippets/gcd.md
@@ -9,10 +9,10 @@ Use `functools.reduce()` and `math.gcd()` over the given list.
 
 ```py
 from functools import reduce
-from math import gcd
+from math import gcd as gcd_from_math
 
 def gcd(numbers):
-  return reduce(gcd, numbers)
+  return reduce(gcd_from_math, numbers)
 ```
 
 ```py


### PR DESCRIPTION
There is a function-redefined bug in origin code. This PR uses an alias to fix the bug.

```py
from functools import reduce
from math import gcd

def gcd(numbers):
  return reduce(gcd, numbers)

gcd([8,36,28])

Traceback (most recent call last):
  File "/Users/felix/workspace/python/30-seconds-of-python/test.py", line 14, in <module>
    gcd([8,36,28])
  File "/Users/felix/workspace/python/30-seconds-of-python/test.py", line 12, in gcd
    return reduce(gcd, numbers)
TypeError: gcd() takes 1 positional argument but 2 were given
```