### PR TITLE
One Liner Implementation to map_dictionary snippet

### DIFF
--- a/snippets/map_dictionary.md
+++ b/snippets/map_dictionary.md
@@ -5,9 +5,9 @@ tags: list,intermediate
 
 Maps the values of a list to a dictionary using a function, where the key-value pairs consist of the original value as the key and the result of the function as the value.
 
-- Use `map` to apply `fn` to each value of the list.
-- Use `zip` to pair original values to the values produced by `fn`.
-- Use `dict` to return a key value pair.
+- Use `map()` to apply `fn` to each value of the list.
+- Use `zip()` to pair original values to the values produced by `fn`.
+- Use `dict()` to return an appropriate dictionary.
 
 ```py
 def map_dictionary(itr, fn):

--- a/snippets/map_dictionary.md
+++ b/snippets/map_dictionary.md
@@ -5,14 +5,13 @@ tags: list,intermediate
 
 Maps the values of a list to a dictionary using a function, where the key-value pairs consist of the original value as the key and the result of the function as the value.
 
-- Use a `for` loop to iterate over the list's values, assigning the values produced by `fn` to each key of the dictionary.
+- Use `map` to apply `fn` to each value of the list.
+- Use `zip` to pair original values to the values produced by `fn`.
+- Use `dict` to return a key value pair.
 
 ```py
 def map_dictionary(itr, fn):
-  ret = {}
-  for x in itr:
-    ret[x] = fn(x)
-  return ret
+  return dict(zip(itr, map(fn, itr)))
 ```
 
 ```py


### PR DESCRIPTION
Improve implementation of `map_dictionary` snippet by replacing for loop with `map` and `zip` .