### PR TITLE
Adding new snippet for fahrenheit to kelvin conversion

### DIFF
--- a/snippets/fahrenheit_to_kelvin.md
+++ b/snippets/fahrenheit_to_kelvin.md
@@ -1,0 +1,17 @@
+---
+title: fahrenheit_to_kelvin
+tags: math, beginner
+---
+
+Converts Fahrenheit to Kelvin.
+
+- Using formula `kelvin = ((fahrenheit + 459.67) * (5/9))`
+
+```py
+def fahrenheit_to_kelvin(fahrenheit):
+  return ((fahrenheit + 459.67) * (5/9))
+```
+
+```py
+fahrenheit_to_kelvin(50) # 283.15000000000003
+```


### PR DESCRIPTION
PR for adding snippet for converting Fahrenheit to Kelvin, which is often used in scientific disciplines like chemistry. 

- Using formula `kelvin = ((fahrenheit + 459.67) * (5/9))`

Tested using: http://www.pythontutor.com/visualize.html