### PR TITLE
Improved `all_unique` , `all_equal` and added new snippet `indices_of_occurrence`

### DIFF
--- a/snippets/all_equal.md
+++ b/snippets/all_equal.md
@@ -5,11 +5,11 @@ tags: list,beginner
 
 Checks if all elements in a list are equal.
 
-- Use `[1:]` and `[:-1]` to compare all the values in the given list.
+- Use `set()` to eliminate duplicate elements and then use `len()` to check if length is 1.
 
 ```py
 def all_equal(lst):
-  return lst[1:] == lst[:-1]
+  return len(set(lst)) == 1
 ```
 
 ```py

--- a/snippets/all_unique.md
+++ b/snippets/all_unique.md
@@ -5,11 +5,18 @@ tags: list,beginner
 
 Returns `True` if all the values in a list are unique, `False` otherwise.
 
-- Use `set()` on the given list to remove duplicates, use `len()` to compare its length with the length of the list.
+- Use `set()` to keep track of elements seen while iterating.
+- Use `in` for checking if an element exists in the set.
+- If it exists return `False`, else return `True`.
 
 ```py
 def all_unique(lst):
-  return len(lst) == len(set(lst))
+  seen = set()
+  for val in lst:
+    if val in seen:
+      return False
+    seen.add(val)
+  return True
 ```
 
 ```py


### PR DESCRIPTION
Previous [`all_unique`](https://github.com/30-seconds/30-seconds-of-python/blob/master/snippets/all_unique.md) creates a set of all the elements in the list. Can be improved by adding short-circuiting logic to it.

`timeit` results for `lst` of size `60_000_000`
```python
In [5]: x = [1, 2, 3, 4, 5, 6]

In [11]: %timeit new_all_unique(x*10_000_000)
279 ms ± 3.68 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [12]: %timeit all_unique(x*10_000_000) # prev version
655 ms ± 11.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
---

Previous [`all_equal`](https://github.com/30-seconds/30-seconds-of-python/blob/master/snippets/all_equal.md) creates two copies of `lst` i.e `[1:]` and `[:-1]` and compares them element by element. Can be improved by using `set()` over `lst` and checking if it's length is `1` or not

`timeit` results for `lst` of size `60_000_000`
```python
In [19]: x = [1, 1, 1, 1, 1, 1]

In [21]: %timeit new_all_eqaul(x*10_000_000)
749 ms ± 8.41 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [23]: %timeit all_equal(x*10_000_000) # prev vesion
1.19 s ± 12 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
---

Added new snippet `indices_of_occurrence` which returns a list of indices of all the occurrences of an elements, if element not found returns empty list `[]`