### PR TITLE
Allow variable number of arguments to union function

### DIFF
--- a/snippets/union.md
+++ b/snippets/union.md
@@ -3,15 +3,18 @@ title: union
 tags: list,beginner
 ---
 
-Returns every element that exists in any of the two lists once.
+Returns every element that exists at least once in any of the lists.
 
-- Create a `set` with all values of `a` and `b` and convert to a `list`.
+- Create a `set` with all values of all the `lists` and convert to a `list`.
 
 ```py
-def union(a, b):
-  return list(set(a + b))
+def union(*lists):
+  summed_lst = []
+  for li in lists:
+    summed_lst += li
+  return list(set(summed_lst))
 ```
 
 ```py
-union([1, 2, 3], [4, 3, 2]) # [1,2,3,4]
+union([1, 2, 2, 3], [4, 3, 2]) # [1, 2, 3, 4]
 ```


### PR DESCRIPTION
To me, it looks like the current definition of the `union` function is a copy of the [union in sets](https://www.w3schools.com/python/ref_set_union.asp), but for lists. However, it does not do so correctly. The set definition allows multiple sets to be passed as the parameters. 

Logically, it follows that this `union` function for lists should do/allow the same thing. Allowing multiple lists as the input also expands on its functionality and makes it more useful while not hampering it's current capabilities.

I feel that this file/function could also be renamed to `list_union.md` instead, in order to differentiate it from the set `union` function. But, I leave that up to the other members of the community to decide....