### PR TITLE
fix bug in rads_to_degrees.md

### DIFF
--- a/snippets/rads_to_degrees.md
+++ b/snippets/rads_to_degrees.md
@@ -11,10 +11,9 @@ Converts an angle from radians to degrees.
 from math import pi
 
 def rads_to_degrees(rad):
-  return (rad * 180.0) / math.pi
+  return (rad * 180.0) / pi
 ```
 
 ```py
-from math import pi
-rads_to_degrees(math.pi / 2) # 90.0
+rads_to_degrees(pi / 2) # 90.0
 ```


### PR DESCRIPTION
The first line is "from math import pi", but use "math.pi" in the following function.

Delete the "import" statement for the example.

**Before**

```py
from math import pi

def rads_to_degrees(rad):
  return (rad * 180.0) / math.pi
```

```py
from math import pi
rads_to_degrees(math.pi / 2) # 90.0
```

**After**

```py
from math import pi

def rads_to_degrees(rad):
  return (rad * 180.0) / pi
```

```py
rads_to_degrees(pi / 2) # 90.0
```