### PR TITLE
docs: fix simple typo, noumbers -> numbers

### DIFF
--- a/snippets/weighted_average.md
+++ b/snippets/weighted_average.md
@@ -3,7 +3,7 @@ title: weighted_average
 tags: math,list,intermediate
 ---
 
-Returns the weighted average of two or more noumbers.
+Returns the weighted average of two or more numbers.
 
 - Use `sum()` to sum the products of the numbers by their weight and to sum the weights.
 - Use `zip()` and a list comprehension to iterate over the pairs of values and weights.


### PR DESCRIPTION
There is a small typo in snippets/weighted_average.md.

Should read `numbers` rather than `noumbers`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md