### PR TITLE
Curry refactoring

### DIFF
--- a/snippets/curry.md
+++ b/snippets/curry.md
@@ -10,12 +10,12 @@ Curries a function.
 ```py
 from functools import partial
 
-def curry(fn, *args):
-  return partial(fn, *args)
+def curry(fn, *args, **kvargs):
+  return partial(fn, *args, **kvargs)
 ```
 
 ```py
-add = lambda x, y: x + y
+def add(x, y): return x + y
 add10 = curry(add, 10)
 add10(20) # 30
 ```


### PR DESCRIPTION
1. Always use a def statement instead of an assignment statement that binds a lambda expression directly to an identifier (c) PEP8
2. To reveal all the features of the curried function, it needs key-value arguments