### PR TITLE
add new snippet string_to_list

### DIFF
--- a/snippets/string_to_list.md
+++ b/snippets/string_to_list.md
@@ -1,0 +1,22 @@
+---
+title: string_to_list
+tags: string,list,beginner
+---
+
+Convert a list of string representations to a list object.
+
+- Use ast module to process trees of the Python abstract syntax grammar.
+- `ast.literal_eval(node_or_string)` safely evaluate a string containing a Python literal.
+- Also support tuples, dicts, sets.
+
+```py
+import ast
+
+def string_to_list(str):
+  return ast.literal_eval(str)
+```
+
+```py
+lst = string_to_list('[0,1,2,[3,4],5]') # [0, 1, 2, [3, 4], 5]
+type(lst) # <class 'list'>
+```


### PR DESCRIPTION
The snippet provides a way to convert a list of string representations("[1, 2, [3, 4], 5]") to a list object([1, 2, [3, 4], 5]). It is [safe](https://docs.python.org/3.6/library/ast.html#ast.literal_eval).

`"[1, 2, [3, 4], 5]"` is a string, `[1, 2, [3, 4], 5]` is a list object.

This can be used in many scenarios. For example, processing .ini configuration files.